### PR TITLE
updated send_one_ping to not print out if exception is thrown

### DIFF
--- a/ping3.py
+++ b/ping3.py
@@ -81,7 +81,6 @@ def send_one_ping(sock: socket, dest_addr: str, icmp_id: int, seq: int, size: in
     try:
         dest_addr = socket.gethostbyname(dest_addr)  # Domain name will translated into IP address, and IP address leaves unchanged.
     except socket.gaierror as e:
-        print("Cannot resolve {}: Unknown host".format(dest_addr))
         raise errors.HostUnknown(dest_addr) from e
     pseudo_checksum = 0  # Pseudo checksum is used to calculate the real checksum.
     icmp_header = struct.pack(ICMP_HEADER_FORMAT, IcmpType.ECHO_REQUEST, ICMP_DEFAULT_CODE, pseudo_checksum, icmp_id, seq)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ping3',
-    version='2.3.1',
+    version='2.3.2',
     description='A pure python3 version of ICMP ping implementation using raw socket.',
     long_description='Ping3 is a pure python3 version of ICMP ping implementation using raw socket. Note that ICMP messages can only be sent from processes running as root.',
     url='https://github.com/kyan001/ping3',


### PR DESCRIPTION
This resolves my created issue of:  https://github.com/kyan001/ping3/issues/11

I do not see any test code that depends upon the print statement.