### PR TITLE
Solution can now also show what IP was used when sending the messages. 

### DIFF
--- a/ping3/__init__.py
+++ b/ping3/__init__.py
@@ -366,7 +366,7 @@ def verbose_ping(dest_addr: str, count: int = 4, interval: float = 0, *args, **k
     """
     resp=myData()
     timeout = kwargs.get("timeout")
-    src = kwargs.get("src")
+    src = kwargs.get("src_addr")
     unit = kwargs.setdefault("unit", "ms")
     i = 0
     while i < count or count == 0:

--- a/ping3/__init__.py
+++ b/ping3/__init__.py
@@ -19,11 +19,20 @@ __version__ = "4.0.0"
 DEBUG = False  # DEBUG: Show debug info for developers. (default False)
 EXCEPTIONS = False  # EXCEPTIONS: Raise exception when delay is not available.
 LOGGER = None  # LOGGER: Record logs into console or file.
+EXTENDED = False # EXTENDED: Return extended object instead of rtt. (default False)
 
 IP_HEADER_FORMAT = "!BBHHHBBHII"
 ICMP_HEADER_FORMAT = "!BBHHH"  # According to netinet/ip_icmp.h. !=network byte order(big-endian), B=unsigned char, H=unsigned short
 ICMP_TIME_FORMAT = "!d"  # d=double
 SOCKET_SO_BINDTODEVICE = 25  # socket.SO_BINDTODEVICE
+
+class myData:
+    version = __version__ + "E"
+    destip = "NA"
+    timeout = 0
+    roundtriptime = 0
+    requests = 0
+    success = False
 
 
 def _debug(*args, **kwargs):
@@ -50,6 +59,7 @@ def _debug(*args, **kwargs):
     LOGGER = LOGGER or get_logger()
     message = " ".join(str(item) for item in args)
     LOGGER.debug(message)
+
 
 
 def _raise(err):
@@ -277,6 +287,7 @@ def ping(dest_addr: str, timeout: int = 4, unit: str = "s", src_addr: str = None
     Raises:
         PingError: Any PingError will raise again if `ping3.EXCEPTIONS` is True.
     """
+    resp=myData()
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_ICMP)
     except PermissionError as err:
@@ -321,8 +332,93 @@ def ping(dest_addr: str, timeout: int = 4, unit: str = "s", src_addr: str = None
             return None
         if unit == "ms":
             delay *= 1000  # in milliseconds
+
+        if EXTENDED == True:
+            resp.destip=str(dest_addr)
+            resp.timeout=timeout
+            resp.roundtriptime=delay
+            resp.requests=1
+            resp.success=True
+            return resp
+            
         return delay
 
+@_func_logger
+def pingE(dest_addr: str, timeout: int = 4, unit: str = "s", src_addr: str = None, ttl: int = None, seq: int = 0, size: int = 56, interface: str = None) -> float:
+    """
+    Send one ping to destination address with the given timeout, return an object with the information.
+
+    Args:
+        dest_addr: The destination address, can be an IP address or a domain name. Ex. "192.168.1.1"/"example.com"
+        timeout: Time to wait for a response, in seconds. Default is 4s, same as Windows CMD. (default 4)
+        unit: The unit of returned value. "s" for seconds, "ms" for milliseconds. (default "s")
+        src_addr: The IP address to ping from. This is for multiple network interfaces. Ex. "192.168.1.20". (default None)
+        interface: LINUX ONLY. The gateway network interface to ping from. Ex. "wlan0". (default None)
+        ttl: The Time-To-Live of the outgoing packet. Default is None, which means using OS default ttl -- 64 onLinux and macOS, and 128 on Windows. (default None)
+        seq: ICMP packet sequence, usually increases from 0 in the same process. (default 0)
+        size: The ICMP packet payload size in bytes. If the input of this is less than the bytes of a double format (usually 8), the size of ICMP packet payload is 8 bytes to hold a time. The max should be the router_MTU(Usually 1480) - IP_Header(20) - ICMP_Header(8). Default is 56, same as in macOS. (default 56)
+
+    Returns:
+        The delay in seconds/milliseconds, False on error and None on timeout.
+
+    Raises:
+        PingError: Any PingError will raise again if `ping3.EXCEPTIONS` is True.
+    """
+    resp=myData()
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_ICMP)
+    except PermissionError as err:
+        if err.errno == errno.EPERM:  # [Errno 1] Operation not permitted
+            _debug("`{}` when create socket.SOCK_RAW, using socket.SOCK_DGRAM instead.".format(err))
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_ICMP)
+        else:
+            raise err
+    with sock:
+        if ttl:
+            try:  # IPPROTO_IP is for Windows and BSD Linux.
+                if sock.getsockopt(socket.IPPROTO_IP, socket.IP_TTL):
+                    sock.setsockopt(socket.IPPROTO_IP, socket.IP_TTL, ttl)
+            except OSError as err:
+                _debug("Set Socket Option `IP_TTL` in `IPPROTO_IP` Failed: {}".format(err))
+            try:
+                if sock.getsockopt(socket.SOL_IP, socket.IP_TTL):
+                    sock.setsockopt(socket.SOL_IP, socket.IP_TTL, ttl)
+            except OSError as err:
+                _debug("Set Socket Option `IP_TTL` in `SOL_IP` Failed: {}".format(err))
+        if interface:
+            sock.setsockopt(socket.SOL_SOCKET, SOCKET_SO_BINDTODEVICE, interface.encode())  # packets will be sent from specified interface.
+            _debug("Socket Interface Binded:", interface)
+        if src_addr:
+            sock.bind((src_addr, 0))  # only packets send to src_addr are received.
+            _debug("Socket Source Address Binded:", src_addr)
+        thread_id = threading.get_native_id() if hasattr(threading, 'get_native_id') else threading.currentThread().ident  # threading.get_native_id() is supported >= python3.8.
+        process_id = os.getpid()  # If ping() run under different process, thread_id may be identical.
+        icmp_id = zlib.crc32("{}{}".format(process_id, thread_id).encode()) & 0xffff  # to avoid icmp_id collision.
+        try:
+            send_one_ping(sock=sock, dest_addr=dest_addr, icmp_id=icmp_id, seq=seq, size=size)
+            delay = receive_one_ping(sock=sock, icmp_id=icmp_id, seq=seq, timeout=timeout)  # in seconds
+        except errors.Timeout as err:
+            _debug(err)
+            _raise(err)
+            return None
+        except errors.PingError as err:
+            _debug(err)
+            _raise(err)
+            return False
+        if delay is None:
+            return None
+        if unit == "ms":
+            delay *= 1000  # in milliseconds
+
+        if EXTENDED == True:
+            resp.destip=str(dest_addr)
+            resp.timeout=timeout
+            resp.roundtriptime=delay
+            resp.requests=1
+            resp.success=True
+            return resp
+        
+        return delay
 
 @_func_logger
 def verbose_ping(dest_addr: str, count: int = 4, interval: float = 0, *args, **kwargs):

--- a/ping3/__init__.py
+++ b/ping3/__init__.py
@@ -15,7 +15,7 @@ import errno
 from . import errors
 from .enums import ICMP_DEFAULT_CODE, IcmpType, IcmpTimeExceededCode, IcmpDestinationUnreachableCode
 
-__version__ = "4.0.0"
+__version__ = "4.0.0E"
 DEBUG = False  # DEBUG: Show debug info for developers. (default False)
 EXCEPTIONS = False  # EXCEPTIONS: Raise exception when delay is not available.
 LOGGER = None  # LOGGER: Record logs into console or file.
@@ -29,6 +29,9 @@ SOCKET_SO_BINDTODEVICE = 25  # socket.SO_BINDTODEVICE
 class myData:
     version = __version__ + "E"
     destip = "NA"
+    destport= 0
+    srcip = "NA"
+    srcport = 0
     timeout = 0
     roundtriptime = 0
     requests = 0
@@ -334,7 +337,9 @@ def ping(dest_addr: str, timeout: int = 4, unit: str = "s", src_addr: str = None
             delay *= 1000  # in milliseconds
 
         if EXTENDED == True:
-            resp.destip=str(dest_addr)
+            resp.destip=str(socket.gethostbyname(dest_addr))
+            resp.srcip=str(sock.getsockname()[0])
+            resp.srcport=sock.getsockname()[1]
             resp.timeout=timeout
             resp.roundtriptime=delay
             resp.requests=1
@@ -343,82 +348,7 @@ def ping(dest_addr: str, timeout: int = 4, unit: str = "s", src_addr: str = None
             
         return delay
 
-@_func_logger
-def pingE(dest_addr: str, timeout: int = 4, unit: str = "s", src_addr: str = None, ttl: int = None, seq: int = 0, size: int = 56, interface: str = None) -> float:
-    """
-    Send one ping to destination address with the given timeout, return an object with the information.
 
-    Args:
-        dest_addr: The destination address, can be an IP address or a domain name. Ex. "192.168.1.1"/"example.com"
-        timeout: Time to wait for a response, in seconds. Default is 4s, same as Windows CMD. (default 4)
-        unit: The unit of returned value. "s" for seconds, "ms" for milliseconds. (default "s")
-        src_addr: The IP address to ping from. This is for multiple network interfaces. Ex. "192.168.1.20". (default None)
-        interface: LINUX ONLY. The gateway network interface to ping from. Ex. "wlan0". (default None)
-        ttl: The Time-To-Live of the outgoing packet. Default is None, which means using OS default ttl -- 64 onLinux and macOS, and 128 on Windows. (default None)
-        seq: ICMP packet sequence, usually increases from 0 in the same process. (default 0)
-        size: The ICMP packet payload size in bytes. If the input of this is less than the bytes of a double format (usually 8), the size of ICMP packet payload is 8 bytes to hold a time. The max should be the router_MTU(Usually 1480) - IP_Header(20) - ICMP_Header(8). Default is 56, same as in macOS. (default 56)
-
-    Returns:
-        The delay in seconds/milliseconds, False on error and None on timeout.
-
-    Raises:
-        PingError: Any PingError will raise again if `ping3.EXCEPTIONS` is True.
-    """
-    resp=myData()
-    try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_ICMP)
-    except PermissionError as err:
-        if err.errno == errno.EPERM:  # [Errno 1] Operation not permitted
-            _debug("`{}` when create socket.SOCK_RAW, using socket.SOCK_DGRAM instead.".format(err))
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_ICMP)
-        else:
-            raise err
-    with sock:
-        if ttl:
-            try:  # IPPROTO_IP is for Windows and BSD Linux.
-                if sock.getsockopt(socket.IPPROTO_IP, socket.IP_TTL):
-                    sock.setsockopt(socket.IPPROTO_IP, socket.IP_TTL, ttl)
-            except OSError as err:
-                _debug("Set Socket Option `IP_TTL` in `IPPROTO_IP` Failed: {}".format(err))
-            try:
-                if sock.getsockopt(socket.SOL_IP, socket.IP_TTL):
-                    sock.setsockopt(socket.SOL_IP, socket.IP_TTL, ttl)
-            except OSError as err:
-                _debug("Set Socket Option `IP_TTL` in `SOL_IP` Failed: {}".format(err))
-        if interface:
-            sock.setsockopt(socket.SOL_SOCKET, SOCKET_SO_BINDTODEVICE, interface.encode())  # packets will be sent from specified interface.
-            _debug("Socket Interface Binded:", interface)
-        if src_addr:
-            sock.bind((src_addr, 0))  # only packets send to src_addr are received.
-            _debug("Socket Source Address Binded:", src_addr)
-        thread_id = threading.get_native_id() if hasattr(threading, 'get_native_id') else threading.currentThread().ident  # threading.get_native_id() is supported >= python3.8.
-        process_id = os.getpid()  # If ping() run under different process, thread_id may be identical.
-        icmp_id = zlib.crc32("{}{}".format(process_id, thread_id).encode()) & 0xffff  # to avoid icmp_id collision.
-        try:
-            send_one_ping(sock=sock, dest_addr=dest_addr, icmp_id=icmp_id, seq=seq, size=size)
-            delay = receive_one_ping(sock=sock, icmp_id=icmp_id, seq=seq, timeout=timeout)  # in seconds
-        except errors.Timeout as err:
-            _debug(err)
-            _raise(err)
-            return None
-        except errors.PingError as err:
-            _debug(err)
-            _raise(err)
-            return False
-        if delay is None:
-            return None
-        if unit == "ms":
-            delay *= 1000  # in milliseconds
-
-        if EXTENDED == True:
-            resp.destip=str(dest_addr)
-            resp.timeout=timeout
-            resp.roundtriptime=delay
-            resp.requests=1
-            resp.success=True
-            return resp
-        
-        return delay
 
 @_func_logger
 def verbose_ping(dest_addr: str, count: int = 4, interval: float = 0, *args, **kwargs):
@@ -434,6 +364,7 @@ def verbose_ping(dest_addr: str, count: int = 4, interval: float = 0, *args, **k
     Returns:
         Formatted ping results printed.
     """
+    resp=myData()
     timeout = kwargs.get("timeout")
     src = kwargs.get("src")
     unit = kwargs.setdefault("unit", "ms")
@@ -444,12 +375,24 @@ def verbose_ping(dest_addr: str, count: int = 4, interval: float = 0, *args, **k
         output_text = "ping '{}'".format(dest_addr)
         output_text += " from '{}'".format(src) if src else ""
         output_text += " ... "
-        delay = ping(dest_addr, seq=i, *args, **kwargs)
+        data = ping(dest_addr, seq=i, *args, **kwargs)
+        
+        if EXTENDED == True and isinstance(data, myData) :
+            print("[EXTENDED] ", end="")
+            delay=data.roundtriptime
+        else:
+            delay=data
+
+            
         print(output_text, end="")
         if delay is None:
             print("Timeout > {}s".format(timeout) if timeout else "Timeout")
         elif delay is False:
             print("Error")
         else:
-            print("{value}{unit}".format(value=int(delay), unit=unit))
+            if EXTENDED == True:
+                print("{value}{unit}".format(value=int(delay), unit=unit),end='')
+                print(" " + data.srcip + " -> " + data.destip + "."  )
+            else:
+                print("{value}{unit}".format(value=int(delay), unit=unit))
         i += 1

--- a/ping3/command_line.py
+++ b/ping3/command_line.py
@@ -25,12 +25,13 @@ def main(assigned_args: list = None):
     parser.add_argument("-s", "--size", dest="size", metavar="SIZE", type=int, default=56, help="The ICMP packet payload size in bytes. Default is 56.")
     parser.add_argument("-D", "--debug", action="store_true", dest="debug", help="Turn on DEBUG mode.")
     parser.add_argument("-E", "--exceptions", action="store_true", dest="exceptions", help="Turn on EXCEPTIONS mode.")
+    parser.add_argument("-X", "--eXtended", action="store_true", dest="extended", help="Turn on EXTENDED mode.")
     args = parser.parse_args(assigned_args)
     ping3.DEBUG = args.debug
     ping3.EXCEPTIONS = args.exceptions
 
     for addr in args.dest_addr:
-        ping3.verbose_ping(addr, count=args.count, ttl=args.ttl, timeout=args.timeout, size=args.size, interval=args.interval, interface=args.interface, src_addr=args.src_addr)
+        ping3.verbose_ping(addr, count=args.count, ttl=args.ttl, timeout=args.timeout, size=args.size, interval=args.interval, interface=args.interface, src_addr=args.src_addr, )
 
 
 if __name__ == "__main__":

--- a/ping3/command_line.py
+++ b/ping3/command_line.py
@@ -15,7 +15,7 @@ def main(assigned_args: list = None):
     """
     parser = argparse.ArgumentParser(prog="ping3", description="A pure python3 version of ICMP ping implementation using raw socket.", epilog="!!Note: ICMP messages can only be sent from processes running as root.")
     parser.add_argument("-v", "--version", action="version", version=ping3.__version__)
-    parser.add_argument(dest="dest_addr", metavar="DEST_ADDR", nargs="*", default=("example.com", "8.8.8.8"), help="The destination address, can be an IP address or a domain name. Ex. 192.168.1.1/example.com.")
+    parser.add_argument(dest="dest_addr", metavar="DEST_ADDR", nargs="*", default=("dns.google", "8.8.8.8"), help="The destination address, can be an IP address or a domain name. Ex. 192.168.1.1/example.com.")
     parser.add_argument("-c", "--count", dest="count", metavar="COUNT", type=int, default=4, help="How many pings should be sent. Default is 4.")
     parser.add_argument("-t", "--timeout", dest="timeout", metavar="TIMEOUT", type=float, default=4, help="Time to wait for a response, in seconds. Default is 4.")
     parser.add_argument("-i", "--interval", dest="interval", metavar="INTERVAL", type=float, default=0, help="Time to wait between each packet, in seconds. Default is 0.")
@@ -29,6 +29,7 @@ def main(assigned_args: list = None):
     args = parser.parse_args(assigned_args)
     ping3.DEBUG = args.debug
     ping3.EXCEPTIONS = args.exceptions
+    ping3.EXTENDED = args.extended
 
     for addr in args.dest_addr:
         ping3.verbose_ping(addr, count=args.count, ttl=args.ttl, timeout=args.timeout, size=args.size, interval=args.interval, interface=args.interface, src_addr=args.src_addr, )

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -38,37 +38,47 @@ class test_ping3(unittest.TestCase):
 
     def test_count(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            command_line.main(["-c", "1", "example.com"])
+            command_line.main(["-c", "1", "dns.google"])
             self.assertEqual(fake_out.getvalue().count("\n"), 1)
 
     def test_timeout(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            command_line.main(["-t", "0.0001", "example.com"])
+            command_line.main(["-t", "0.0001", "dns.google"])
             self.assertRegex(fake_out.getvalue(), r".*Timeout \> [0-9\.]+s.*")
 
     @unittest.skipIf(sys.platform.startswith("win"), "Linux and macOS Only")
     def test_ttl(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            command_line.main(["-T", "1", "example.com"])
-            self.assertRegex(fake_out.getvalue(), r".*Error.*")
+            command_line.main(["-T", "1", "dns.google"])
+            self.assertRegex(fake_out.getvalue(), r".*Timeout.*")
+
+    @unittest.skipIf(sys.platform.startswith("win"), "Linux and macOS Only")
+    def test_ttl2(self):
+        with patch("sys.stdout", new=io.StringIO()) as fake_out:
+            command_line.main(["-T", "1", "dns.google"])
+            self.assertRegex(fake_out.getvalue(), r".*Timeout.*")     
 
     def test_size(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            command_line.main(["-s", "100", "example.com"])
+            command_line.main(["-s", "100", "dns.google"])
             self.assertRegex(fake_out.getvalue(), r".*[0-9]+ms.*")
             with self.assertRaises(OSError):
-                command_line.main(["-s", "99999", "example.com"])
+                command_line.main(["-s", "99999", "dns.google"])
 
     def test_interval(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
             start_time = time.time()
-            command_line.main(["-i", "1", "example.com"])
+            command_line.main(["-i", "1", "dns.google"])
             end_time = time.time()
             self.assertTrue((end_time - start_time) >= 3)  # time_expect = (count - 1) * interval
             self.assertNotIn("Timeout", fake_out.getvalue())
 
     @unittest.skipUnless(sys.platform == "linux", "Linux only")
     def test_interface(self):
+        if os.geteuid() != 0:
+            print("Needs sudo.")
+            self.fail("Need sudo.");
+            
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
             try:
                 route_cmd = os.popen("ip -o -4 route show to default")
@@ -80,7 +90,7 @@ class test_ping3(unittest.TestCase):
                 socket.if_nametoindex(my_interface)  # test if the interface exists.
             except OSError:
                 self.fail("Interface Name Error: {}".format(my_interface))
-            command_line.main(["-I", my_interface, "example.com"])
+            command_line.main(["-I", my_interface, "dns.google"])
             self.assertRegex(fake_out.getvalue(), r".*[0-9]+ms.*")
 
     def test_src_addr(self):
@@ -89,18 +99,24 @@ class test_ping3(unittest.TestCase):
             if my_ip in ("127.0.0.1", "127.0.1.1"):  # This may caused by /etc/hosts settings.
                 dest_addr = my_ip  # only localhost can send and receive from 127.0.0.1 (or 127.0.1.1 on Ubuntu).
             else:
-                dest_addr = "example.com"
+                dest_addr = "dns.google"
             command_line.main(["-S", my_ip, dest_addr])
             self.assertRegex(fake_out.getvalue(), r".*[0-9]+ms.*")
 
     def test_debug(self):
         with patch("sys.stdout", new=io.StringIO()), patch("sys.stderr", new=io.StringIO()) as fake_err:
-            command_line.main(["--debug", "-c", "1", "example.com"])
+            command_line.main(["--debug", "-c", "1", "dns.google"])
             self.assertIn("[DEBUG]", fake_err.getvalue())
 
+    def test_extended(self):
+        with patch("sys.stdout", new=io.StringIO()) as fake_out:
+            command_line.main(["--eXtended", "-c", "1", "dns.google"])
+            self.assertIn("[EXTENDED]", fake_out.getvalue())
+
+            
     def test_exceptions(self):
         with self.assertRaises(errors.Timeout):
-            command_line.main(["--exceptions", "-t", "0.0001", "example.com"])
+            command_line.main(["--exceptions", "-t", "0.0001", "dns.google"])
 
 
 if __name__ == "__main__":

--- a/tests/test_ping3.py
+++ b/tests/test_ping3.py
@@ -23,32 +23,32 @@ class test_ping3(unittest.TestCase):
         self.assertIsInstance(ping3.__version__, str)
 
     def test_ping_normal(self):
-        delay = ping3.ping("example.com")
+        delay = ping3.ping("dns.google")
         self.assertIsInstance(delay, float)
 
     def test_verbose_ping_normal(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            ping3.verbose_ping("example.com")
+            ping3.verbose_ping("dns.google")
             self.assertRegex(fake_out.getvalue(), r".*[0-9]+ms.*")
 
     def test_ping_timeout(self):
-        delay = ping3.ping("example.com", timeout=0.0001)
+        delay = ping3.ping("dns.google", timeout=0.0001)
         self.assertIsNone(delay)
 
     def test_ping_timeout_exception(self):
         with patch("ping3.EXCEPTIONS", True):
             with self.assertRaises(ping3.errors.Timeout):
-                ping3.ping("example.com", timeout=0.0001)
+                ping3.ping("dns.google", timeout=0.0001)
 
     def test_verbose_ping_timeout(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            ping3.verbose_ping("example.com", timeout=0.0001)
+            ping3.verbose_ping("dns.google", timeout=0.0001)
             self.assertRegex(fake_out.getvalue(), r".*Timeout \> [0-9\.]+s.*")
 
     def test_verbose_ping_timeout_exception(self):
         with patch("ping3.EXCEPTIONS", True):
             with self.assertRaises(ping3.errors.Timeout):
-                ping3.verbose_ping("example.com", timeout=0.0001)
+                ping3.verbose_ping("dns.google", timeout=0.0001)
 
     def test_ping_error(self):
         delay = ping3.ping("not.exist.com")
@@ -62,38 +62,43 @@ class test_ping3(unittest.TestCase):
                 self.assertEqual(e.dest_addr, "not.exist.com")
 
     def test_ping_seq(self):
-        delay = ping3.ping("example.com", seq=199)
+        delay = ping3.ping("dns.google", seq=199)
         self.assertIsInstance(delay, float)
 
     def test_ping_size(self):
-        delay = ping3.ping("example.com", size=100)
+        delay = ping3.ping("dns.google", size=100)
         self.assertIsInstance(delay, float)
 
     def test_ping_size_exception(self):
         with self.assertRaises(OSError):
-            ping3.ping("example.com", size=99999)  # most router has 1480 MTU, which is IP_Header(20) + ICMP_Header(8) + ICMP_Payload(1452)
+            ping3.ping("dns.google", size=99999)  # most router has 1480 MTU, which is IP_Header(20) + ICMP_Header(8) + ICMP_Payload(1452)
 
     def test_verbose_ping_size(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            ping3.verbose_ping("example.com", size=100)
+            ping3.verbose_ping("dns.google", size=100)
             self.assertRegex(fake_out.getvalue(), r".*[0-9]+ms.*")
 
     def test_verbose_ping_size_exception(self):
         with self.assertRaises(OSError):
-            ping3.verbose_ping("example.com", size=99999)
+            ping3.verbose_ping("dns.google", size=99999)
 
     def test_ping_unit(self):
-        delay = ping3.ping("example.com", unit="ms")
+        delay = ping3.ping("dns.google", unit="ms")
         self.assertIsInstance(delay, float)
         self.assertTrue(delay > 1)
 
     def test_verbose_ping_unit(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            ping3.verbose_ping("example.com", unit="ms")
+            ping3.verbose_ping("dns.google", unit="ms")
             self.assertRegex(fake_out.getvalue(), r".*[0-9]+ms.*")
 
     @unittest.skipUnless(sys.platform == "linux", "Linux only")
     def test_ping_interface(self):
+        if os.geteuid() != 0:
+            print("Needs sudo, will cause an error.", end="")
+            self.fail("Needs sudo.")
+
+            
         try:
             route_cmd = os.popen("ip -o -4 route show to default")
             default_route = route_cmd.read()
@@ -104,12 +109,16 @@ class test_ping3(unittest.TestCase):
             socket.if_nametoindex(my_interface)  # test if the interface exists.
         except OSError:
             self.fail("Interface Name Error: {}".format(my_interface))
-        dest_addr = "example.com"
+        dest_addr = "dns.google"
         delay = ping3.ping(dest_addr, interface=my_interface)
         self.assertIsInstance(delay, float)
 
     @unittest.skipUnless(sys.platform == "linux", "Linux only")
     def test_verbose_ping_interface(self):
+        if os.geteuid() != 0:
+            print("Needs sudo, will cause an error.", end="")
+            self.fail("Needs sudo.")
+            
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
             try:
                 route_cmd = os.popen("ip -o -4 route show to default")
@@ -121,7 +130,7 @@ class test_ping3(unittest.TestCase):
                 socket.if_nametoindex(my_interface)  # test if the interface exists.
             except OSError:
                 self.fail("Interface Name Error: {}".format(my_interface))
-            dest_addr = "example.com"
+            dest_addr = "dns.google"
             ping3.verbose_ping(dest_addr, interface=my_interface)
             self.assertRegex(fake_out.getvalue(), r".*[0-9]+ms.*")
 
@@ -130,7 +139,7 @@ class test_ping3(unittest.TestCase):
         if my_ip in ("127.0.0.1", "127.0.1.1"):  # This may caused by /etc/hosts settings.
             dest_addr = my_ip  # only localhost can send and receive from 127.0.0.1 (or 127.0.1.1 on Ubuntu).
         else:
-            dest_addr = "example.com"
+            dest_addr = "dns.google"
         delay = ping3.ping(dest_addr, src_addr=my_ip)
         self.assertIsInstance(delay, float)
 
@@ -140,53 +149,57 @@ class test_ping3(unittest.TestCase):
             if my_ip in ("127.0.0.1", "127.0.1.1"):  # This may caused by /etc/hosts settings.
                 dest_addr = my_ip  # only localhost can send and receive from 127.0.0.1 (or 127.0.1.1 on Ubuntu).
             else:
-                dest_addr = "example.com"
+                dest_addr = "dns.google"
             ping3.verbose_ping(dest_addr, src_addr=my_ip)
             self.assertRegex(fake_out.getvalue(), r".*[0-9]+ms.*")
 
     @unittest.skipIf(sys.platform.startswith("win"), "Linux and macOS Only")
     def test_ping_ttl(self):
-        delay = ping3.ping("example.com", ttl=1)
+        delay = ping3.ping("dns.google", ttl=1)
         self.assertIn(delay, (None, False))  # When TTL expired, some routers report nothing.
 
     @unittest.skipIf(sys.platform.startswith("win"), "Linux and macOS Only")
     def test_ping_ttl_exception(self):
         with patch("ping3.EXCEPTIONS", True):
             with self.assertRaises((ping3.errors.TimeToLiveExpired, ping3.errors.Timeout)):  # When TTL expired, some routers report nothing.
-                ping3.ping("example.com", ttl=1)
+                ping3.ping("dns.google", ttl=1)
 
     @unittest.skipIf(sys.platform.startswith("win"), "Linux and macOS Only")
     def test_verbose_ping_ttl(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            ping3.verbose_ping("example.com", ttl=1)
+            ping3.verbose_ping("dns.google", ttl=1)
             self.assertNotRegex(fake_out.getvalue(), r".*[0-9]+ms.*")
 
     @unittest.skipIf(sys.platform.startswith("win"), "Linux and macOS Only")
     def test_verbose_ping_ttl_exception(self):
         with patch("sys.stdout", new=io.StringIO()), patch("ping3.EXCEPTIONS", True):
             with self.assertRaises((ping3.errors.TimeToLiveExpired, ping3.errors.Timeout)):  # When TTL expired, some routers report nothing.
-                ping3.verbose_ping("example.com", ttl=1)
+                ping3.verbose_ping("dns.google", ttl=1)
 
     def test_verbose_ping_count(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            ping3.verbose_ping("example.com", count=1)
+            ping3.verbose_ping("dns.google", count=1)
             self.assertEqual(fake_out.getvalue().count("\n"), 1)
 
     def test_verbose_ping_interval(self):
         with patch("sys.stdout", new=io.StringIO()) as fake_out:
-            delay = ping3.ping("example.com")
+            delay = ping3.ping("dns.google")
             self.assertTrue(0 < delay < 0.75)  # If interval does not work, the total delay should be < 3s (4 * 0.75s)
             start_time = time.time()
-            ping3.verbose_ping("example.com", interval=1)  # If interval does work, the total delay should be > 3s (3 * 1s)
+            ping3.verbose_ping("dns.google", interval=1)  # If interval does work, the total delay should be > 3s (3 * 1s)
             end_time = time.time()
             self.assertTrue((end_time - start_time) >= 3)  # time_expect = (count - 1) * interval
             self.assertNotIn("Timeout", fake_out.getvalue())  # Ensure no timeout
 
     def test_DEBUG(self):
         with patch("ping3.DEBUG", True), patch("sys.stderr", new=io.StringIO()):
-            delay = ping3.ping("example.com")
+            delay = ping3.ping("dns.google")
             self.assertIsNotNone(ping3.LOGGER)
 
+    def test_EXTENDED(self):
+        with patch("ping3.EXTENDED", True), patch("sys.stderr", new=io.StringIO()):
+            obj = ping3.ping("dns.google")
+            self.assertIsInstance(obj, ping3.myData, "Wrong type returned")
 
 if __name__ == "__main__":
     unittest.main(verbosity=2, exit=False)


### PR DESCRIPTION
I had a need to see what IP was used after the lookup (DNS that resolves to many addresses). I did this by changing the return format to an object. ATM, the port makes no sense, but if UDP/TCP are used it can be used. Hope it could be useful. I also changed the tests, so that those that require root privileges FAIL directly and logs that they "Needs sudo". I also change from example.com to dns.google. Hope I left no bug. 