### PR TITLE
Error handling in command line if PermissionError is raised

### DIFF
--- a/ping3/command_line.py
+++ b/ping3/command_line.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 import ping3
 
@@ -30,7 +31,13 @@ def main(assigned_args: list = None):
     ping3.EXCEPTIONS = args.exceptions
 
     for addr in args.dest_addr:
-        ping3.verbose_ping(addr, count=args.count, ttl=args.ttl, timeout=args.timeout, size=args.size, interval=args.interval, interface=args.interface, src_addr=args.src_addr)
+        try:
+            ping3.verbose_ping(addr, count=args.count, ttl=args.ttl, timeout=args.timeout, size=args.size, interval=args.interval, interface=args.interface, src_addr=args.src_addr)
+        except PermissionError:
+            if args.exceptions:
+                raise
+            else:
+                print(f"PermissionError (destination {addr}): in your system you might need to use root privileges to use ping3", file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With the change:
```
$ ping3 google.com
PermissionError (destination google.com): in your system you might need to use root privileges to use ping3
```

Or:
```
$ ping3 google.com --exceptions
Traceback (most recent call last):
  File "/home/carles/git/testing-cloudscraper/venv/lib/python3.11/site-packages/ping3/__init__.py", line 281, in ping
    sock = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_ICMP)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/socket.py", line 232, in __init__
```
etc. etc. etc.
