### PR TITLE
Add missing "py.typed" file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,8 @@ py-modules = ["ping3"]
 [tool.setuptools.dynamic]
 version = {attr = "ping3.__version__"}
 
+[tool.setuptools.package-data]
+"ping3" = ["py.typed"]
+
 [tool.setuptools.packages.find]
 exclude = ["contrib", "docs", "tests"]


### PR DESCRIPTION
Hi again.

For type checkers to work properly, the library must package a `py.typed` file, see [PEP 561](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data).

Otherwise, type checkers may complain that the library is not typed.