### PR TITLE
Also use datagram icmp_id and seq to match destination unreachable messages

### DIFF
--- a/ping3/__init__.py
+++ b/ping3/__init__.py
@@ -332,11 +332,11 @@ def receive_one_ping(sock: socket.socket, icmp_id: int, seq: int, timeout: int):
         icmp_header = read_icmp_header(icmp_header_raw)
         _debug("Received ICMP header:", icmp_header)
         _debug("Received ICMP payload:", icmp_payload_raw)
-        if icmp_header["type"] == icmp_type.TIME_EXCEEDED:  # TIME_EXCEEDED has no icmp_id and icmp_seq. Usually they are 0.
-            # According to RFC 792, Time Exceeded messages include the IP Header
-            # and the first 64 bits of the Datagram which is the original ICMP
-            # Header. Thus we can extract the icmp_id and seq_id from the returned
-            # Datagram ICMP Header to match the packet when the TTL expires.
+        if icmp_header["type"] in (icmp_type.TIME_EXCEEDED, icmp_type.DESTINATION_UNREACHABLE):  # TIME_EXCEEDED and DESTINATION_UNREACHABLE have no icmp_id and icmp_seq. Usually they are 0.
+            # According to RFC 792, both Time Exceeded and Destination Unreachable
+            # messages include the IP Header and the first 64 bits of the Datagram
+            # which is the original ICMP Header. Thus we can extract the icmp_id
+            # and seq from the returned Datagram ICMP Header to match the packet.
             original_icmp_header_offset = struct.calcsize(IPV4_HEADER_FORMAT if is_ipv4(sock) else IPV6_HEADER_FORMAT)
             original_icmp_header_slice = slice(original_icmp_header_offset, original_icmp_header_offset + struct.calcsize(ICMP_HEADER_FORMAT))
             original_icmp_header = read_icmp_header(icmp_payload_raw[original_icmp_header_slice])
@@ -352,21 +352,22 @@ def receive_one_ping(sock: socket.socket, icmp_id: int, seq: int, timeout: int):
             if original_icmp_header["seq"] != seq:  # ECHO_REPLY should match the ICMP SEQ field.
                 _debug("IMCP SEQ dismatch. Packet filtered out.")
                 continue
-            if icmp_header["code"] == IcmpTimeExceededCode.TTL_EXPIRED:  # Windows raw socket cannot get TTL_EXPIRED. See https://stackoverflow.com/questions/43239862/socket-sock-raw-ipproto-icmp-cant-read-ttl-response.
-                raise errors.TimeToLiveExpired(ip_header=ip_header, icmp_header=icmp_header)  # Some router does not report TTL expired and then timeout shows.
-            raise errors.TimeExceeded()
-        if icmp_header["type"] == icmp_type.DESTINATION_UNREACHABLE:  # DESTINATION_UNREACHABLE has no icmp_id and icmp_seq. Usually they are 0.
-            if is_ipv4(sock):
-                if icmp_header["code"] == IcmpV4DestinationUnreachableCode.DESTINATION_HOST_UNREACHABLE:
-                    raise errors.DestinationHostUnreachable(ip_header=ip_header, icmp_header=icmp_header)
-            else:
-                if icmp_header["code"] == IcmpV6DestinationUnreachableCode.ADDRESS_UNREACHABLE:
-                    raise errors.AddressUnreachable(ip_header=ip_header, icmp_header=icmp_header)
-                elif icmp_header["code"] == IcmpV6DestinationUnreachableCode.PORT_UNREACHABLE:
-                    raise errors.PortUnreachable(ip_header=ip_header, icmp_header=icmp_header)
-            raise errors.DestinationUnreachable(
-                ip_header=ip_header, icmp_header=icmp_header
-            )
+            if icmp_header["type"] == icmp_type.TIME_EXCEEDED:
+                if icmp_header["code"] == IcmpTimeExceededCode.TTL_EXPIRED:  # Windows raw socket cannot get TTL_EXPIRED. See https://stackoverflow.com/questions/43239862/socket-sock-raw-ipproto-icmp-cant-read-ttl-response.
+                    raise errors.TimeToLiveExpired(ip_header=ip_header, icmp_header=icmp_header)  # Some router does not report TTL expired and then timeout shows.
+                raise errors.TimeExceeded()
+            if icmp_header["type"] == icmp_type.DESTINATION_UNREACHABLE:
+                if is_ipv4(sock):
+                    if icmp_header["code"] == IcmpV4DestinationUnreachableCode.DESTINATION_HOST_UNREACHABLE:
+                        raise errors.DestinationHostUnreachable(ip_header=ip_header, icmp_header=icmp_header)
+                else:
+                    if icmp_header["code"] == IcmpV6DestinationUnreachableCode.ADDRESS_UNREACHABLE:
+                        raise errors.AddressUnreachable(ip_header=ip_header, icmp_header=icmp_header)
+                    elif icmp_header["code"] == IcmpV6DestinationUnreachableCode.PORT_UNREACHABLE:
+                        raise errors.PortUnreachable(ip_header=ip_header, icmp_header=icmp_header)
+                raise errors.DestinationUnreachable(
+                    ip_header=ip_header, icmp_header=icmp_header
+                )
         if icmp_header["id"]:
             if icmp_header["type"] == icmp_type.ECHO_REQUEST:  # filters out the ECHO_REQUEST itself.
                 _debug("ECHO_REQUEST received. Packet filtered out.")


### PR DESCRIPTION
Hi Kyan,

I have run into a very similar bug to the one fixed in #91.

I was periodically pinging some device, but the raw socket receives all ICMP traffic on the interface, and picks up ambient `DESTINATION_UNREACHABLE` messages generated by some completely unrelated process. The original code does not filter these out, wrongly raising one of the Unreachable errors.

This Pull Request extends the deep inspection logic added in #91 to also apply in the case of `DESTINATION_UNREACHABLE` messages, as per [RFC 792](https://datatracker.ietf.org/doc/html/rfc792) the format of these is the same as `TIME_EXCEEDED`.


Reproducible Example, with debug logs:
```python
while True:
    ping3.ping("127.0.0.1")
    time.sleep(1)
```
and in another terminal simulating background noise by sending UDP packets to a closed port:
```bash
while true; do 
  echo "Test packet data" | nc -u -w 1 127.0.0.1 9999
  sleep 0.0001
done
```
**Before:**
The background UDP noise triggers a Destination Unreachable error.
```
[DEBUG] Function called: ping(127.0.0.1)
...
[DEBUG] Function called: receive_one_ping({'sock': <socket.socket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_RAW, proto=1, laddr=('0.0.0.0', 1)>, 'icmp_id': 37140, 'seq': 0, 'timeout': 4})
[DEBUG] Timeout time: Tue Mar 10 14:48:50 2026 (1773154130.1480649)
[DEBUG] Timeout left: 4.00s
[DEBUG] Received time: Tue Mar 10 14:48:46 2026 (1773154126.1481442))
[DEBUG] Has IP header: True
[DEBUG] Received IP header: {'version': 69, 'tos': 192, 'len': 73, 'id': 14579, 'flags': 0, 'ttl': 64, 'protocol': 1, 'checksum': 17151, 'src_addr': '127.0.0.1', 'dest_addr': '127.0.0.1'}
[DEBUG] Received ICMP header: {'type': 3, 'code': 3, 'checksum': 11838, 'id': 0, 'seq': 0}
[DEBUG] Received ICMP payload: b"E\x00\x00-\xcc\xa7@\x00@\x11p\x16\x7f\x00\x00\x01\x7f\x00\x00\x01\x9ds'\x0f\x00\x19\xfe,Test packet data\n"
[DEBUG] Destination unreachable. (Host='127.0.0.1')
```
**After:**
The unrelated error is filtered out
```
[DEBUG] Function called: ping(127.0.0.1)
...
[DEBUG] Function called: receive_one_ping({'sock': <socket.socket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_RAW, proto=1, laddr=('0.0.0.0', 1)>, 'icmp_id': 23635, 'seq': 0, 'timeout': 4})
[DEBUG] Timeout time: Tue Mar 10 14:43:48 2026 (1773153828.948878)
[DEBUG] Timeout left: 4.00s
[DEBUG] Received time: Tue Mar 10 14:43:44 2026 (1773153824.9489248))
[DEBUG] Has IP header: True
[DEBUG] Received IP header: {'version': 69, 'tos': 192, 'len': 73, 'id': 58204, 'flags': 0, 'ttl': 64, 'protocol': 1, 'checksum': 39061, 'src_addr': '127.0.0.1', 'dest_addr': '127.0.0.1'}
[DEBUG] Received ICMP header: {'type': 3, 'code': 3, 'checksum': 7111, 'id': 0, 'seq': 0}
[DEBUG] Received ICMP payload: b"E\x00\x00-\xd9G@\x00@\x11cv\x7f\x00\x00\x01\x7f\x00\x00\x01\xaf\xea'\x0f\x00\x19\xfe,Test packet data\n"
[DEBUG] ICMP ID dismatch. Packet filtered out.
...
[DEBUG] Received ICMP header: {'type': 0, 'code': 0, 'checksum': 5561, 'id': 23635, 'seq': 0}
[DEBUG] Received ICMP payload: b'A\xdal\x0b\x88<\xb81QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ'
[DEBUG] ICMP ID: 23635 , Expected: 23635
[DEBUG] Received sent time: Tue Mar 10 14:43:44 2026 (1773153824.9487422)
[DEBUG] Function returned: receive_one_ping -> 0.00045943260192871094
[DEBUG] Function returned: ping -> 0.00045943260192871094
```